### PR TITLE
fix: ソーシャルボタンのスタイル修正

### DIFF
--- a/components/Share.vue
+++ b/components/Share.vue
@@ -56,7 +56,7 @@ export default {
 </script>
 
 <style scoped>
-@media (min-width: 1160px) {
+@media (min-width: 820px) {
   .share {
     width: 24px;
     padding-top: 16px;


### PR DESCRIPTION
原因がmin-width: 1160pxの指定で、それ以下のサイズではシェアボタンにサイズが指定されてませんでした！

なので、min-width: 820pxの指定で大丈夫そうでした！