### PR TITLE
Breadcrumbでカテゴリーがない場合レンダリングしないように修正

### DIFF
--- a/components/Breadcrumb.vue
+++ b/components/Breadcrumb.vue
@@ -3,10 +3,7 @@
     <li class="breadcrumbList">
       <nuxt-link to="/">記事一覧</nuxt-link>
     </li>
-    <li
-      v-if="category !== undefined && category !== null"
-      class="breadcrumbList"
-    >
+    <li v-if="hasCategory(category)" class="breadcrumbList">
       <nuxt-link :to="`/category/${category.id}/page/1`">{{
         category.name
       }}</nuxt-link>
@@ -21,6 +18,11 @@ export default {
       type: Object,
       required: false,
       default: () => ({}),
+    },
+  },
+  methods: {
+    hasCategory(category) {
+      return Object.keys(category).length > 0;
     },
   },
 };


### PR DESCRIPTION
`category` のオブジェクトが空の場合は末端の `<li>` をレンダリングしないようにしました。

<img width="393" alt="Screen Shot 2021-04-28 at 21 42 11" src="https://user-images.githubusercontent.com/1996642/116405442-9d0ff300-a86a-11eb-8a5e-fbb7e5af2f93.png">
現在のTOPページではカテゴリがないため、aタグの遷移先が category/undefined/page となってしまってレンダリングされています。

見た目上は２つめがないので問題ないように見えるのですが、
スクリーンリーダーで要素をフォーカスすると「２つのリストアイテムがある」状態と判定され
２つめの中身があることを期待させてしまいかねないので、それであればない場合は描画しないように対応しました。