### PR TITLE
日付部分をtime要素でマークアップ

### DIFF
--- a/components/Meta.vue
+++ b/components/Meta.vue
@@ -4,7 +4,9 @@
     <div class="meta">
       <span class="timestamp">
         <img src="/images/icon_clock.svg" alt />
-        {{ $dayjs(createdAt).format('YYYY/MM/DD') }}
+        <time :datetime="$dayjs(createdAt).format('YYYY-MM-DD')">
+          {{ $dayjs(createdAt).format('YYYY/MM/DD') }}
+        </time>
       </span>
       <span v-if="author" class="author">
         <img src="/images/icon_author.svg" alt />


### PR DESCRIPTION
ちょっとした改善です

```html
<time datetime="2021-04-21">
2021/04/21
</time>
```

上記のようにマークアップすることでよりセマンティクスに日付を定義できます。

**参考**

- [`<time>` - HTML: HyperText Markup Language | MDN](https://developer.mozilla.org/ja/docs/Web/HTML/Element/time)
- [HTML Standard 日本語訳 - 4.5.14 time要素](https://momdo.github.io/html/text-level-semantics.html#the-time-element)