### PR TITLE
:pencil2: Typoを修正

### DIFF
--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -20,7 +20,7 @@ export default {
       prefix: 'og: http://ogp.me/ns#',
       lang: 'ja',
     },
-    titleTemplete: '%s | microCMSブログ',
+    titleTemplate: '%s | microCMSブログ',
     meta: [
       { charset: 'utf-8' },
       { name: 'viewport', content: 'width=device-width, initial-scale=1' },

--- a/pages/404.vue
+++ b/pages/404.vue
@@ -15,7 +15,7 @@
 export default {
   head() {
     return {
-      titleTemplete: null,
+      titleTemplate: null,
       title: 'ページが見つかりません | microCMSブログ',
     };
   },

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -132,7 +132,7 @@ export default {
   },
   head() {
     return {
-      titleTemplete: null,
+      titleTemplate: null,
       title: 'microCMSブログ',
     };
   },

--- a/pages/search/index.vue
+++ b/pages/search/index.vue
@@ -164,7 +164,7 @@ export default {
   },
   head() {
     return {
-      titleTemplete: null,
+      titleTemplate: null,
       title: 'microCMSブログ',
     };
   },


### PR DESCRIPTION
各設定ファイル、コンポーネントのhead metaで、`titleTemplate`を`titleTemplete`とTypoしていると思われるため、blogタイトル等が反映されておらず、それを修正した。