### PR TITLE
[fix] 空or空文字の場合、後続処理を行わないように変更

### DIFF
--- a/components/Search.vue
+++ b/components/Search.vue
@@ -5,11 +5,7 @@
       class="input"
       type="text"
       @keypress="setSearchable"
-      @keypress.enter="
-        (e) =>
-          searchable &&
-          $router.push({ path: '/search', query: { q: e.target.value } })
-      "
+      @keypress.enter="search"
     />
   </label>
 </template>
@@ -24,6 +20,12 @@ export default {
   methods: {
     setSearchable() {
       this.searchable = true;
+    },
+    search(e) {
+      if (!e.target.value.trim() || !this.searchable) {
+        return;
+      }
+      this.$router.push({ path: '/search', query: { q: e.target.value } });
     },
   },
 };

--- a/pages/search/index.vue
+++ b/pages/search/index.vue
@@ -140,7 +140,7 @@ export default {
       this.searchable = true;
     },
     async search(q) {
-      if (!q || !this.searchable) {
+      if (!q.trim() || !this.searchable) {
         return;
       }
       this.loadingStart();


### PR DESCRIPTION
## 改善詳細
①サイト内検索欄において、空or空文字のみの状態でEnterキーを押下するとローディングがずっとでたままになる。
②searchページに遷移後の検索欄では空の場合はガードされているが、空文字はガードされていない。

## 期待する見せ方・挙動
①空or空文字のみの場合、Enterキーが押されても検索処理を行わないようにする。

## 再現手順
1. [microCMSブログ](https://blog.microcms.io/) にアクセス。
2. サイト内検索欄に何も入力せずEnterキーを押下する。
3. `https://blog.microcms.io/search?q=`に遷移するが、ローディングがずっとでたままになる。

## コメント
参考になるコードを公開していただきありがとうございます！
検索実行時の挙動が少し気になったので、改善案をプルリクさせていただきました。
ご一考いただければと存じます。