### PR TITLE
検索パラメータの不要なエンコードを削除

### DIFF
--- a/functions/search.js
+++ b/functions/search.js
@@ -14,9 +14,7 @@ exports.handler = async (event) => {
   return client
     .get({
       endpoint: 'blog',
-      queries: {
-        q: encodeURIComponent(q),
-      },
+      queries: { q },
     })
     .then((data) => {
       return {


### PR DESCRIPTION
SDK利用時は内部でエンコードと合わせて2重エンコードとなってしまうため修正しました。
日本語・アルファベットの双方が正しく検索できることを確認済みです。