### PR TITLE
fix: Replace the "microcms" to SERVICE_ID

### DIFF
--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -1,5 +1,5 @@
 import { client } from './utils/microcms';
-const { API_KEY, GA_ID, FB_PIXEL_ID } = process.env;
+const { API_KEY, SERVICE_ID, GA_ID, FB_PIXEL_ID } = process.env;
 
 export default {
   target: 'static',
@@ -150,7 +150,7 @@ export default {
   },
   microcms: {
     options: {
-      serviceDomain: 'microcms',
+      serviceDomain: SERVICE_ID,
       apiKey: API_KEY,
     },
     mode: process.env.NODE_ENV === 'production' ? 'server' : 'all',


### PR DESCRIPTION
The reason for the [401 Error by following the document](https://github.com/microcmsio/microcms-blog/issues/102) in the issue was that the value of `serviceDomain` in `nuxt.config.js` was left hardcoded. 

I replaced `"microcss"` with `SERVICE_ID` and it worked fine.