### PR TITLE
githubの表記ゆれを見つけたので修正

### DIFF
--- a/components/Header.vue
+++ b/components/Header.vue
@@ -193,7 +193,7 @@ export default {
               path: 'https://blog.microcms.io/',
             },
             {
-              name: 'github',
+              name: 'Github',
               path: 'https://github.com/microcmsio',
             },
             {

--- a/components/Header.vue
+++ b/components/Header.vue
@@ -193,7 +193,7 @@ export default {
               path: 'https://blog.microcms.io/',
             },
             {
-              name: 'Github',
+              name: 'GitHub',
               path: 'https://github.com/microcmsio',
             },
             {


### PR DESCRIPTION
サポートメニューの箇所が`github`になっていたので`GitHub`修正しました。お時間あるときにご確認お願いします！！

![Screenshot from 2021-09-27 12-32-13](https://user-images.githubusercontent.com/39504660/134841655-06edfb4a-0096-4439-87ba-cbeb514522a5.png)


