### PR TITLE
検索結果ページで著者なしの記事を表示できるように修正

### DIFF
--- a/pages/search/index.vue
+++ b/pages/search/index.vue
@@ -43,7 +43,7 @@
                   <dd>
                     <Meta
                       :created-at="content.publishedAt || content.createdAt"
-                      :author="data.writer !== null ? data.writer.name : ''"
+                      :author="content.writer !== null ? content.writer.name : ''"
                       :category="content.category"
                       :tags="content.tag"
                     />

--- a/pages/search/index.vue
+++ b/pages/search/index.vue
@@ -43,7 +43,7 @@
                   <dd>
                     <Meta
                       :created-at="content.publishedAt || content.createdAt"
-                      :author="content.writer.name"
+                      :author="data.writer !== null ? data.writer.name : ''"
                       :category="content.category"
                       :tags="content.tag"
                     />


### PR DESCRIPTION
検索結果ページで、著者なしの記事が表示されない不具合がありました。
著者がない記事が返ってきた場合でも、`writer.name`をMetaコンポーネントに渡そうとしていたのが原因のようです。
著者が登録されている場合のみ、`writer.name`を渡すよう修正しましたのでご確認おねがいします。