### PR TITLE
記事ページのバナーを追従

### DIFF
--- a/components/Latest.vue
+++ b/components/Latest.vue
@@ -25,11 +25,6 @@ export default {
 
 <style scoped>
 @media (min-width: 1160px) {
-  .wrapper {
-    position: sticky !important;
-    top: 115px;
-  }
-
   .pageTitle {
     font-size: 20px;
     font-weight: bold;

--- a/pages/_slug/index.vue
+++ b/pages/_slug/index.vue
@@ -64,12 +64,14 @@
         </div>
       </article>
       <aside class="aside">
-        <Banner :id="`blog-${id}`" :banner="banner" />
         <Search />
         <Categories :categories="categories" />
         <Tags :tags="tags" />
         <PopularArticles :contents="popularArticles" />
-        <Latest :contents="contents" />
+        <div class="followArea">
+          <Banner :id="`blog-${id}`" :banner="banner" />
+          <Latest :contents="contents" />
+        </div>
       </aside>
     </div>
     <Footer />
@@ -220,6 +222,11 @@ export default {
     display: flex;
     justify-content: space-between;
     margin-top: 40px;
+  }
+
+  .followArea {
+    position: sticky !important;
+    top: 115px;
   }
 
   .banner {

--- a/pages/_slug/index.vue
+++ b/pages/_slug/index.vue
@@ -300,6 +300,7 @@ export default {
 @media (min-width: 820px) and (max-width: 1160px) {
   .wrapper {
     position: relative;
+    margin-top: 40px;
   }
 
   .divider {
@@ -418,6 +419,7 @@ export default {
 @media (min-width: 600px) and (max-width: 820px) {
   .wrapper {
     position: relative;
+    margin-top: 40px;
   }
 
   .divider {

--- a/pages/draft/index.vue
+++ b/pages/draft/index.vue
@@ -337,6 +337,7 @@ export default {
 @media (min-width: 820px) and (max-width: 1160px) {
   .wrapper {
     position: relative;
+    margin-top: 40px;
   }
 
   .divider {
@@ -456,6 +457,7 @@ export default {
 @media (min-width: 600px) and (max-width: 820px) {
   .wrapper {
     position: relative;
+    margin-top: 40px;
   }
 
   .divider {

--- a/pages/draft/index.vue
+++ b/pages/draft/index.vue
@@ -52,11 +52,13 @@
         </div>
       </article>
       <aside class="aside">
-        <Banner :id="`draft-${data.id}`" :banner="banner" />
         <Search />
         <Categories :categories="categories" />
         <Tags :tags="tags" />
-        <Latest :contents="contents" />
+        <div class="followArea">
+          <Banner :id="`draft-${data.id}`" :banner="banner" />
+          <Latest :contents="contents" />
+        </div>
       </aside>
     </div>
     <Footer />
@@ -256,6 +258,11 @@ export default {
     display: flex;
     justify-content: space-between;
     margin-top: 40px;
+  }
+
+  .followArea {
+    position: sticky !important;
+    top: 115px;
   }
 
   .banner {


### PR DESCRIPTION
## 概要

記事詳細とドラフトページのサイドバーのバナーを新着記事の上に配置して追従させる