### PR TITLE
記事冒頭の事前説明と前後ブログの表示を行う

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,11 +42,14 @@ type: リスト形式
 | category      | カテゴリー | コンテンツ参照 - カテゴリー |
 | tag           | タグ       | 複数コンテンツ参照 - タグ   |
 | toc_visible   | 目次       | 真偽値                      |
+| prior_explanation | 事前説明       | リッチエディタ              |
 | body          | 本文       | リッチエディタ              |
 | description   | 概要       | テキストフィールド          |
 | ogimage       | OGP 画像   | 画像                        |
 | writer        | 著者       | コンテンツ参照 - 著者       |
 | partner       | パートナー | コンテンツ参照 - パートナー |
+| previous_blog | 前の記事   | コンテンツ参照 - ブログ |
+| next_blog     | 次の記事   | コンテンツ参照 - ブログ |
 | related_blogs | 関連記事   | 複数コンテンツ参照 - ブログ |
 | cv_point | CVポイント   | 繰り返し（※上限1に設定） - カスタムフィールド |
 

--- a/components/NextBlogNavigation.vue
+++ b/components/NextBlogNavigation.vue
@@ -45,7 +45,7 @@ export default {
       position: relative;
 
       a {
-        color: #331cbf;
+        color: var(--color-purple);
         text-decoration: underline;
       }
     }
@@ -61,8 +61,8 @@ export default {
         left: 0;
         width: 8px;
         height: 8px;
-        border-bottom: 2px solid #331cbf;
-        border-left: 2px solid #331cbf;
+        border-bottom: 2px solid var(--color-purple);
+        border-left: 2px solid var(--color-purple);
         transform: translateX(50%) rotate(45deg);
       }
     }
@@ -79,8 +79,8 @@ export default {
         right: 0;
         width: 8px;
         height: 8px;
-        border-top: 2px solid #331cbf;
-        border-right: 2px solid #331cbf;
+        border-top: 2px solid var(--color-purple);
+        border-right: 2px solid var(--color-purple);
         transform: translateX(-50%) rotate(45deg);
       }
     }

--- a/components/NextBlogNavigation.vue
+++ b/components/NextBlogNavigation.vue
@@ -1,15 +1,36 @@
 <template>
-  <div class="navigation">
+  <div v-if="previous || next" class="navigation">
     <ul>
       <li class="previous">
-        <a href="#">Next.jsとAuth0で会員制メディアを作る【1. 認証編】</a>
+        <nuxt-link v-if="previous && previous.id" :to="`/${previous.id}`">{{
+          previous.title
+        }}</nuxt-link>
       </li>
       <li class="next">
-        <a href="#">Next.jsとAuth0で会員制メディアを作る【3. 完成編】</a>
+        <nuxt-link v-if="next && next.id" :to="`/${next.id}`">{{
+          next.title
+        }}</nuxt-link>
       </li>
     </ul>
   </div>
 </template>
+
+<script>
+export default {
+  props: {
+    previous: {
+      type: Object,
+      required: false,
+      default: undefined,
+    },
+    next: {
+      type: Object,
+      required: false,
+      default: undefined,
+    },
+  },
+};
+</script>
 
 <style scoped>
 .navigation {

--- a/components/NextBlogNavigation.vue
+++ b/components/NextBlogNavigation.vue
@@ -1,0 +1,74 @@
+<template>
+  <div class="navigation">
+    <ul>
+      <li class="previous">
+        <a href="#">Next.jsとAuth0で会員制メディアを作る【1. 認証編】</a>
+      </li>
+      <li class="next">
+        <a href="#">Next.jsとAuth0で会員制メディアを作る【3. 完成編】</a>
+      </li>
+    </ul>
+  </div>
+</template>
+
+<style scoped>
+.navigation {
+  margin: 60px 0;
+
+  ul {
+    display: flex;
+    justify-content: space-between;
+
+    li {
+      width: 40%;
+      position: relative;
+
+      a {
+        color: #331cbf;
+        text-decoration: underline;
+      }
+    }
+
+    .previous {
+      padding-left: 32px;
+
+      ::before {
+        content: '';
+        display: block;
+        position: absolute;
+        top: 8px;
+        left: 0;
+        width: 8px;
+        height: 8px;
+        border-bottom: 2px solid #331cbf;
+        border-left: 2px solid #331cbf;
+        transform: translateX(50%) rotate(45deg);
+      }
+    }
+
+    .next {
+      padding-right: 32px;
+      text-align: right;
+
+      ::before {
+        content: '';
+        display: block;
+        position: absolute;
+        top: 8px;
+        right: 0;
+        width: 8px;
+        height: 8px;
+        border-top: 2px solid #331cbf;
+        border-right: 2px solid #331cbf;
+        transform: translateX(-50%) rotate(45deg);
+      }
+    }
+  }
+}
+
+@media (max-width: 600px) {
+  .navigation {
+    font-size: 14px;
+  }
+}
+</style>

--- a/components/PriorExplanation.vue
+++ b/components/PriorExplanation.vue
@@ -10,8 +10,8 @@ export default {
   props: {
     value: {
       type: String,
-      required: true,
-      default: '',
+      required: false,
+      default: null,
     },
   },
 };

--- a/components/PriorExplanation.vue
+++ b/components/PriorExplanation.vue
@@ -1,0 +1,82 @@
+<template>
+  <div class="priorExplanation">
+    <h2>記事を読みはじめる前に</h2>
+    <div class="preContents">
+      <p>
+        事前準備として、本記事で使用するサービスのアカウント登録を済ませておきましょう。
+      </p>
+      <ul>
+        <li>
+          <a
+            href="https://microcms.io/"
+            target="_blank"
+            rel="noopener noreferrer"
+            >microCMS</a
+          >：APIベースの日本製のヘッドレスCMS
+        </li>
+        <li>
+          <a href="#">Auth0</a
+          >：クラウドサービスやアプリで利用されている認証プラットフォームサービス
+        </li>
+        <li><a href="#">Vercel</a>：CI/CDとWebサーバが合わさったサービス</li>
+      </ul>
+      <p>
+        <br />本記事で使用する、microCMSのスキーマ設定ファイルをダウンロードできます。
+      </p>
+      <ul>
+        <li><a href="#">articles-schema.json (0.3KB)</a></li>
+      </ul>
+      <p><br />本記事のソースコードは下記GitHubで閲覧できます。</p>
+      <ul>
+        <li>
+          <a
+            href="https://github.com/microcmsio/microcms-sample"
+            target="_blank"
+            rel="noopener noreferrer"
+            >https://github.com/microcmsio/microcms-sample</a
+          >
+        </li>
+      </ul>
+    </div>
+  </div>
+</template>
+
+<style scoped>
+.priorExplanation {
+  margin-bottom: 40px;
+  line-height: 1.8;
+  letter-spacing: 0.2px;
+
+  h2 {
+    padding: 10px 24px;
+    border-radius: 5px 5px 0 0;
+    background-color: #331cbf;
+    color: #fff;
+    font-weight: bold;
+  }
+
+  .preContents {
+    padding: 24px;
+    border: 1px solid #331cbf;
+    border-top: 0;
+    border-radius: 0 0 5px 5px;
+
+    a {
+      color: #331cbf;
+      text-decoration: underline;
+    }
+
+    ul {
+      list-style: disc;
+      padding-left: 1em;
+      margin-top: 10px;
+    }
+  }
+}
+
+@media (max-width: 600px) {
+  .priorExplanation {
+    font-size: 14px;
+  }
+}
+</style>

--- a/components/PriorExplanation.vue
+++ b/components/PriorExplanation.vue
@@ -1,45 +1,21 @@
 <template>
-  <div class="priorExplanation">
+  <div v-if="value" class="priorExplanation">
     <h2>記事を読みはじめる前に</h2>
-    <div class="preContents">
-      <p>
-        事前準備として、本記事で使用するサービスのアカウント登録を済ませておきましょう。
-      </p>
-      <ul>
-        <li>
-          <a
-            href="https://microcms.io/"
-            target="_blank"
-            rel="noopener noreferrer"
-            >microCMS</a
-          >：APIベースの日本製のヘッドレスCMS
-        </li>
-        <li>
-          <a href="#">Auth0</a
-          >：クラウドサービスやアプリで利用されている認証プラットフォームサービス
-        </li>
-        <li><a href="#">Vercel</a>：CI/CDとWebサーバが合わさったサービス</li>
-      </ul>
-      <p>
-        <br />本記事で使用する、microCMSのスキーマ設定ファイルをダウンロードできます。
-      </p>
-      <ul>
-        <li><a href="#">articles-schema.json (0.3KB)</a></li>
-      </ul>
-      <p><br />本記事のソースコードは下記GitHubで閲覧できます。</p>
-      <ul>
-        <li>
-          <a
-            href="https://github.com/microcmsio/microcms-sample"
-            target="_blank"
-            rel="noopener noreferrer"
-            >https://github.com/microcmsio/microcms-sample</a
-          >
-        </li>
-      </ul>
-    </div>
+    <div class="preContents" v-html="value"></div>
   </div>
 </template>
+
+<script>
+export default {
+  props: {
+    value: {
+      type: String,
+      required: true,
+      default: '',
+    },
+  },
+};
+</script>
 
 <style scoped>
 .priorExplanation {
@@ -47,7 +23,7 @@
   line-height: 1.8;
   letter-spacing: 0.2px;
 
-  h2 {
+  & >>> h2 {
     padding: 10px 24px;
     border-radius: 5px 5px 0 0;
     background-color: #331cbf;
@@ -61,12 +37,12 @@
     border-top: 0;
     border-radius: 0 0 5px 5px;
 
-    a {
+    & >>> a {
       color: #331cbf;
       text-decoration: underline;
     }
 
-    ul {
+    & >>> ul {
       list-style: disc;
       padding-left: 1em;
       margin-top: 10px;

--- a/components/PriorExplanation.vue
+++ b/components/PriorExplanation.vue
@@ -26,19 +26,19 @@ export default {
   & >>> h2 {
     padding: 10px 24px;
     border-radius: 5px 5px 0 0;
-    background-color: #331cbf;
+    background-color: var(--color-purple);
     color: #fff;
     font-weight: bold;
   }
 
   .preContents {
     padding: 24px;
-    border: 1px solid #331cbf;
+    border: 1px solid var(--color-purple);
     border-top: 0;
     border-radius: 0 0 5px 5px;
 
     & >>> a {
-      color: #331cbf;
+      color: var(--color-purple);
       text-decoration: underline;
     }
 

--- a/pages/_slug/index.vue
+++ b/pages/_slug/index.vue
@@ -45,65 +45,11 @@
               :tags="tag"
               :is-single-page="true"
             />
-            <div class="preDescription">
-              <h2>記事を読みはじめる前に</h2>
-              <div class="preContents">
-                <p>
-                  事前準備として、本記事で使用するサービスのアカウント登録を済ませておきましょう。
-                </p>
-                <ul>
-                  <li>
-                    <a
-                      href="https://microcms.io/"
-                      target="_blank"
-                      rel="noopener noreferrer"
-                      >microCMS</a
-                    >：APIベースの日本製のヘッドレスCMS
-                  </li>
-                  <li>
-                    <a href="#">Auth0</a
-                    >：クラウドサービスやアプリで利用されている認証プラットフォームサービス
-                  </li>
-                  <li>
-                    <a href="#">Vercel</a>：CI/CDとWebサーバが合わさったサービス
-                  </li>
-                </ul>
-                <p>
-                  <br />本記事で使用する、microCMSのスキーマ設定ファイルをダウンロードできます。
-                </p>
-                <ul>
-                  <li><a href="#">articles-schema.json (0.3KB)</a></li>
-                </ul>
-                <p><br />本記事のソースコードは下記GitHubで閲覧できます。</p>
-                <ul>
-                  <li>
-                    <a
-                      href="https://github.com/microcmsio/microcms-sample"
-                      target="_blank"
-                      rel="noopener noreferrer"
-                      >https://github.com/microcmsio/microcms-sample</a
-                    >
-                  </li>
-                </ul>
-              </div>
-            </div>
+            <PriorExplanation />
             <Toc :id="id" :toc="toc" :visible="toc_visible" />
             <Post :body="body" />
             <ShareButtons :id="id" :title="title" />
-            <div class="navigation">
-              <ul>
-                <li class="previous">
-                  <a href="#"
-                    >Next.jsとAuth0で会員制メディアを作る【1. 認証編】</a
-                  >
-                </li>
-                <li class="next">
-                  <a href="#"
-                    >Next.jsとAuth0で会員制メディアを作る【3. 完成編】</a
-                  >
-                </li>
-              </ul>
-            </div>
+            <NextBlogNavigation />
             <ConversionPoint
               :id="id"
               :contents="cv_point"
@@ -199,7 +145,6 @@ export default {
       $(elm).attr('data-src', elm.attribs.src);
       $(elm).removeAttr('src');
     });
-
     return {
       ...data,
       popularArticles,
@@ -253,92 +198,6 @@ export default {
   margin-top: 10px;
   font-size: 14px;
   font-weight: bold;
-}
-
-.preDescription {
-  margin-bottom: 40px;
-  line-height: 1.8;
-  letter-spacing: 0.2px;
-
-  h2 {
-    padding: 10px 24px;
-    border-radius: 5px 5px 0 0;
-    background-color: #331cbf;
-    color: #fff;
-    font-weight: bold;
-  }
-
-  .preContents {
-    padding: 24px;
-    border: 1px solid #331cbf;
-    border-top: 0;
-    border-radius: 0 0 5px 5px;
-
-    a {
-      color: #331cbf;
-      text-decoration: underline;
-    }
-
-    ul {
-      list-style: disc;
-      padding-left: 1em;
-      margin-top: 10px;
-    }
-  }
-}
-
-.navigation {
-  margin: 60px 0;
-
-  ul {
-    display: flex;
-    justify-content: space-between;
-
-    li {
-      width: 40%;
-      position: relative;
-
-      a {
-        color: #331cbf;
-        text-decoration: underline;
-      }
-    }
-
-    .previous {
-      padding-left: 32px;
-
-      ::before {
-        content: '';
-        display: block;
-        position: absolute;
-        top: 8px;
-        left: 0;
-        width: 8px;
-        height: 8px;
-        border-bottom: 2px solid #331cbf;
-        border-left: 2px solid #331cbf;
-        transform: translateX(50%) rotate(45deg);
-      }
-    }
-
-    .next {
-      padding-right: 32px;
-      text-align: right;
-
-      ::before {
-        content: '';
-        display: block;
-        position: absolute;
-        top: 8px;
-        right: 0;
-        width: 8px;
-        height: 8px;
-        border-top: 2px solid #331cbf;
-        border-right: 2px solid #331cbf;
-        transform: translateX(-50%) rotate(45deg);
-      }
-    }
-  }
 }
 
 @media (min-width: 1160px) {
@@ -767,10 +626,6 @@ export default {
     font-weight: bold;
     font-size: 24px;
     color: #2b2c30;
-  }
-  .preDescription,
-  .navigation {
-    font-size: 14px;
   }
 }
 </style>

--- a/pages/_slug/index.vue
+++ b/pages/_slug/index.vue
@@ -146,7 +146,6 @@ export default {
       $(elm).removeAttr('src');
     });
     return {
-      prior_explanation: '',
       ...data,
       popularArticles,
       banner,

--- a/pages/_slug/index.vue
+++ b/pages/_slug/index.vue
@@ -45,9 +45,65 @@
               :tags="tag"
               :is-single-page="true"
             />
+            <div class="preDescription">
+              <h2>記事を読みはじめる前に</h2>
+              <div class="preContents">
+                <p>
+                  事前準備として、本記事で使用するサービスのアカウント登録を済ませておきましょう。
+                </p>
+                <ul>
+                  <li>
+                    <a
+                      href="https://microcms.io/"
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      >microCMS</a
+                    >：APIベースの日本製のヘッドレスCMS
+                  </li>
+                  <li>
+                    <a href="#">Auth0</a
+                    >：クラウドサービスやアプリで利用されている認証プラットフォームサービス
+                  </li>
+                  <li>
+                    <a href="#">Vercel</a>：CI/CDとWebサーバが合わさったサービス
+                  </li>
+                </ul>
+                <p>
+                  <br />本記事で使用する、microCMSのスキーマ設定ファイルをダウンロードできます。
+                </p>
+                <ul>
+                  <li><a href="#">articles-schema.json (0.3KB)</a></li>
+                </ul>
+                <p><br />本記事のソースコードは下記GitHubで閲覧できます。</p>
+                <ul>
+                  <li>
+                    <a
+                      href="https://github.com/microcmsio/microcms-sample"
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      >https://github.com/microcmsio/microcms-sample</a
+                    >
+                  </li>
+                </ul>
+              </div>
+            </div>
             <Toc :id="id" :toc="toc" :visible="toc_visible" />
             <Post :body="body" />
             <ShareButtons :id="id" :title="title" />
+            <div class="navigation">
+              <ul>
+                <li class="previous">
+                  <a href="#"
+                    >Next.jsとAuth0で会員制メディアを作る【1. 認証編】</a
+                  >
+                </li>
+                <li class="next">
+                  <a href="#"
+                    >Next.jsとAuth0で会員制メディアを作る【3. 完成編】</a
+                  >
+                </li>
+              </ul>
+            </div>
             <ConversionPoint
               :id="id"
               :contents="cv_point"
@@ -197,6 +253,92 @@ export default {
   margin-top: 10px;
   font-size: 14px;
   font-weight: bold;
+}
+
+.preDescription {
+  margin-bottom: 40px;
+  line-height: 1.8;
+  letter-spacing: 0.2px;
+
+  h2 {
+    padding: 10px 24px;
+    border-radius: 5px 5px 0 0;
+    background-color: #331cbf;
+    color: #fff;
+    font-weight: bold;
+  }
+
+  .preContents {
+    padding: 24px;
+    border: 1px solid #331cbf;
+    border-top: 0;
+    border-radius: 0 0 5px 5px;
+
+    a {
+      color: #331cbf;
+      text-decoration: underline;
+    }
+
+    ul {
+      list-style: disc;
+      padding-left: 1em;
+      margin-top: 10px;
+    }
+  }
+}
+
+.navigation {
+  margin: 60px 0;
+
+  ul {
+    display: flex;
+    justify-content: space-between;
+
+    li {
+      width: 40%;
+      position: relative;
+
+      a {
+        color: #331cbf;
+        text-decoration: underline;
+      }
+    }
+
+    .previous {
+      padding-left: 32px;
+
+      ::before {
+        content: '';
+        display: block;
+        position: absolute;
+        top: 8px;
+        left: 0;
+        width: 8px;
+        height: 8px;
+        border-bottom: 2px solid #331cbf;
+        border-left: 2px solid #331cbf;
+        transform: translateX(50%) rotate(45deg);
+      }
+    }
+
+    .next {
+      padding-right: 32px;
+      text-align: right;
+
+      ::before {
+        content: '';
+        display: block;
+        position: absolute;
+        top: 8px;
+        right: 0;
+        width: 8px;
+        height: 8px;
+        border-top: 2px solid #331cbf;
+        border-right: 2px solid #331cbf;
+        transform: translateX(-50%) rotate(45deg);
+      }
+    }
+  }
 }
 
 @media (min-width: 1160px) {
@@ -625,6 +767,10 @@ export default {
     font-weight: bold;
     font-size: 24px;
     color: #2b2c30;
+  }
+  .preDescription,
+  .navigation {
+    font-size: 14px;
   }
 }
 </style>

--- a/pages/_slug/index.vue
+++ b/pages/_slug/index.vue
@@ -45,11 +45,11 @@
               :tags="tag"
               :is-single-page="true"
             />
-            <PriorExplanation />
+            <PriorExplanation :value="prior_explanation" />
             <Toc :id="id" :toc="toc" :visible="toc_visible" />
             <Post :body="body" />
             <ShareButtons :id="id" :title="title" />
-            <NextBlogNavigation />
+            <NextBlogNavigation :previous="previous_blog" :next="next_blog" />
             <ConversionPoint
               :id="id"
               :contents="cv_point"
@@ -146,6 +146,7 @@ export default {
       $(elm).removeAttr('src');
     });
     return {
+      prior_explanation: '',
       ...data,
       popularArticles,
       banner,


### PR DESCRIPTION
下記の2コンポーネントを追加しました。どちらもmicroCMSへの入稿を行うことで表示ができます。

# 記事冒頭

![image](https://user-images.githubusercontent.com/2342648/192250777-bdfd6920-dcf9-4ba1-9ed3-bbf50bd76f65.png)

# 前の記事・次の記事

![image](https://user-images.githubusercontent.com/2342648/192251287-21a1c19d-6674-48e6-90ea-051305cb88a1.png)
