### PR TITLE
Fix twitter url in article details

### DIFF
--- a/components/Writer.vue
+++ b/components/Writer.vue
@@ -18,10 +18,7 @@
           <nuxt-link :to="`/author/${writer.id}/`" class="authorLink">
             {{ writer.name }}
           </nuxt-link>
-          <a
-            class="twitterLink"
-            :href="`https://twitter.com/${writer.twitter || writer.id}`"
-          >
+          <a v-if="writer.twitter" class="twitterLink" :href="writer.twitter">
             <img class="twitter" src="/images/icon_twitter.svg" alt="Twitter" />
           </a>
         </dt>


### PR DESCRIPTION
記事フッタで著者のTwitter URLが正しく扱われていなかったため修正しました。