### PR TITLE
コンバージョンの画像サイズを大きくする

### DIFF
--- a/components/ConversionPoint.vue
+++ b/components/ConversionPoint.vue
@@ -134,7 +134,7 @@ export default {
   }
 
   .mainTitle {
-    font-size: 24px;
+    font-size: 20px;
     font-weight: bold;
     line-height: 1.7;
     margin-bottom: 20px;
@@ -244,9 +244,8 @@ export default {
     }
 
     .upperContents {
-      padding: 0 20px;
       display: grid;
-      grid-template-columns: 60% auto;
+      grid-template-columns: 40% auto;
       align-items: center;
       grid-gap: 5%;
     }
@@ -267,6 +266,7 @@ export default {
 
     .mainText {
       margin-bottom: 0;
+      font-size: 14px;
     }
 
     .buttonWrapper {
@@ -423,6 +423,7 @@ export default {
 
     .mainText {
       margin-bottom: 0;
+      font-size: 14px;
     }
   }
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **スタイルの改善**
  - レイアウトと外観の調整が行われ、タイトルのフォントサイズが24pxから20pxに変更されました。
  - グリッドレイアウトの幅分布が変更され、視覚的な階層が改善されました。
  - テキストサイズが14pxに統一され、読みやすさが向上しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->