### PR TITLE
詳細画面に更新日を表示するよう変更

### DIFF
--- a/components/Meta.vue
+++ b/components/Meta.vue
@@ -23,10 +23,16 @@
     </div>
 
     <div class="meta">
-      <span class="timestamp">
+      <span class="timestamp" title="公開日">
         <img src="/images/icon_clock.svg" width="20" height="20" alt />
         <time :datetime="$dayjs(createdAt).format('YYYY-MM-DD')">
           {{ $dayjs(createdAt).format('YYYY/MM/DD') }}
+        </time>
+      </span>
+      <span v-if="isRevised" class="timestamp" title="更新日">
+        <img src="/images/icon_update.svg" width="20" height="20" alt />
+        <time :datetime="$dayjs(revisedAt).format('YYYY-MM-DD')">
+          {{ $dayjs(revisedAt).format('YYYY/MM/DD') }}
         </time>
       </span>
       <span v-if="author" class="author">
@@ -43,6 +49,11 @@ export default {
     createdAt: {
       type: String,
       required: true,
+    },
+    revisedAt: {
+      type: String,
+      required: false,
+      default: undefined,
     },
     author: {
       type: Object,
@@ -63,6 +74,17 @@ export default {
       type: Boolean,
       required: false,
       default: false,
+    },
+  },
+  computed: {
+    isRevised() {
+      if (this.revisedAt === undefined) {
+        return false;
+      }
+      return (
+        this.$dayjs(this.revisedAt).format('YYYY-MM-DD') !==
+        this.$dayjs(this.createdAt).format('YYYY-MM-DD')
+      );
     },
   },
 };

--- a/pages/_slug/index.vue
+++ b/pages/_slug/index.vue
@@ -184,7 +184,9 @@ export default {
       const oneYearAgoDate = new Date();
       oneYearAgoDate.setFullYear(currentDate.getFullYear() - 1);
 
-      const createdAtDate = new Date(this.publishedAt || this.createdAt);
+      const createdAtDate = new Date(
+        this.revisedAt || this.publishedAt || this.createdAt
+      );
 
       // createdAtが1年前の日付かどうか判定
       return createdAtDate < oneYearAgoDate;

--- a/pages/_slug/index.vue
+++ b/pages/_slug/index.vue
@@ -44,6 +44,7 @@
             <h1 class="title">{{ title }}</h1>
             <Meta
               :created-at="publishedAt || createdAt"
+              :revised-at="revisedAt"
               :author="writer"
               :category="category"
               :tags="tag"

--- a/static/images/icon_update.svg
+++ b/static/images/icon_update.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="#919299" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="feather feather-rotate-cw"><polyline points="23 4 23 10 17 10"></polyline><path d="M20.49 15a9 9 0 1 1-2.12-9.36L23 10"></path></svg>


### PR DESCRIPTION
記事詳細画面に公開日の隣に更新日も表示するよう変更しました。

![スクリーンショット_2024-09-25_13_44_58](https://github.com/user-attachments/assets/df69d760-65d3-43a8-81d5-b452d436115c)

## 仕様
- 公開日と更新日が1日以上ズレていた場合に表示される
- 記事公開から1年以上経過している際に表示される黄色アラートは、1年以内に記事が更新されていれば表示しない
