### PR TITLE
[update] ヘッダーにパートナーページへの導線を追加

### DIFF
--- a/components/Footer.vue
+++ b/components/Footer.vue
@@ -259,13 +259,23 @@
 
         <li class="sitemapListItem">
           <section>
-            <h3 class="categoryTitle">コンタクト</h3>
+            <h3 class="categoryTitle">お問い合わせ</h3>
             <ul class="menuList">
               <li class="menuListItem">
                 <a class="menuLink" href="https://microcms.io/contact"
-                  >お問い合わせ</a
+                  >新規導入に関するご相談</a
                 >
               </li>
+              <li class="menuListItem">
+                <a
+                  class="menuLink"
+                  href="https://microcms.io/partners#consultation"
+                  >パートナー紹介のご相談</a
+                >
+              </li>
+            </ul>
+            <h3 class="categoryTitle">パートナー</h3>
+            <ul class="menuList">
               <li class="menuListItem">
                 <a class="menuLink" href="https://microcms.io/for-partners"
                   >パートナーになる</a

--- a/components/Header.vue
+++ b/components/Header.vue
@@ -89,16 +89,11 @@
           </li>
         </ul>
 
-        <ul class="lists isMobileReverse">
-          <li class="list">
+        <ul class="lists listsButton">
+          <li class="list listSignin">
             <a class="signin" href="https://app.microcms.io/signin">ログイン</a>
           </li>
-          <li class="list">
-            <a class="contact" href="https://microcms.io/contact"
-              >お問い合わせ</a
-            >
-          </li>
-          <li class="list">
+          <li class="list noMargin">
             <a class="signup" :href="`https://app.microcms.io${params}`"
               >無料ではじめる</a
             >
@@ -209,6 +204,21 @@ export default {
           ],
         },
         {
+          name: 'パートナー',
+          path: '',
+          isDropDown: true,
+          contents: [
+            {
+              name: 'パートナーになる',
+              path: 'https://microcms.io/for-partners',
+            },
+            {
+              name: 'パートナーを探す',
+              path: 'https://microcms.io/partners',
+            },
+          ],
+        },
+        {
           name: '料金プラン',
           path: 'https://microcms.io/pricing',
           isDropDown: false,
@@ -219,6 +229,21 @@ export default {
           path: 'https://microcms.io/ebook',
           isDropDown: false,
           contents: [],
+        },
+        {
+          name: 'お問い合わせ',
+          path: '',
+          isDropDown: true,
+          contents: [
+            {
+              name: '新規導入に関するご相談',
+              path: 'https://microcms.io/contact',
+            },
+            {
+              name: 'パートナー紹介のご相談',
+              path: 'https://microcms.io/partners#consultation',
+            },
+          ],
         },
       ],
     };
@@ -247,7 +272,7 @@ export default {
 </script>
 
 <style scoped>
-@media (min-width: 800px) {
+@media (min-width: 1240px) {
   .header {
     position: fixed;
     top: 0;
@@ -275,13 +300,14 @@ export default {
 
     a {
       display: block;
-      height: 28px;
+      width: 160px;
+      height: 30.3px;
     }
   }
 
   .logoImg {
-    width: auto;
-    height: 28px;
+    width: 160px;
+    height: auto;
   }
 
   .menuBtn {
@@ -312,16 +338,24 @@ export default {
     &.isDesktop {
       display: flex;
     }
+
+    &.listsButton {
+      margin-left: 10px;
+    }
   }
 
   .list {
-    margin-right: 32px;
+    margin-right: 22px;
     padding: 8px 0;
     white-space: nowrap;
     position: relative;
 
     &.noMargin {
       margin: 0;
+    }
+
+    &.listSignin {
+      margin-right: 16px;
     }
 
     a,
@@ -333,25 +367,17 @@ export default {
         background-color: var(--color-primary);
         color: #fff;
         text-align: center;
-        padding: 8px 32px;
-        font-size: 16px;
-      }
-
-      &.contact {
-        border-radius: 4px;
-        border: 1px solid var(--color-primary);
-        color: var(--color-primary);
-        text-align: center;
-        padding: 8px 32px;
+        padding: 12px 34px;
         font-size: 16px;
       }
 
       &.signin {
         border-radius: 4px;
+        border: 1px solid var(--color-primary);
+        color: var(--color-primary);
         text-align: center;
-        padding: 8px 32px;
-        border-left: 1px solid #eee;
-        margin-right: -32px;
+        padding: 11px 32px;
+        font-size: 16px;
       }
     }
   }
@@ -371,7 +397,7 @@ export default {
       display: inline-block;
       width: 16px;
       height: 16px;
-      margin-left: 4px;
+      margin-left: 6px;
       background: url('/images/icon_arrow_bottom.svg') center center no-repeat;
       background-size: contain;
       position: absolute;
@@ -422,7 +448,7 @@ export default {
   }
 }
 
-@media (max-width: 800px) {
+@media (max-width: 1240px) {
   .header {
     position: fixed;
     top: 0;
@@ -495,6 +521,17 @@ export default {
       display: flex;
       flex-direction: column-reverse;
     }
+
+    &.listsButton {
+      display: flex;
+      flex-direction: row-reverse;
+      padding-right: 10px;
+      padding-left: 10px;
+      .list {
+        width: calc(100% / 2);
+        padding: 0 8px;
+      }
+    }
   }
 
   .list {
@@ -515,17 +552,13 @@ export default {
         margin-bottom: 8px;
       }
 
-      &.contact {
+      &.signin {
         border-radius: 4px;
         color: var(--color-primary);
         border: 1px solid var(--color-primary);
         text-align: center;
         font-weight: bold;
         margin-bottom: 8px;
-      }
-
-      &.signin {
-        display: none;
       }
     }
 

--- a/components/Header.vue
+++ b/components/Header.vue
@@ -20,6 +20,9 @@
       <div class="menu" :class="{ isOpen: open }">
         <ul class="lists isMobile">
           <li class="list">
+            <a href="https://microcms.io/contact">お問い合わせ</a>
+          </li>
+          <li class="list">
             <a href="https://microcms.io/pricing">料金プラン</a>
           </li>
           <li class="list">

--- a/components/Header.vue
+++ b/components/Header.vue
@@ -89,8 +89,8 @@
           </li>
         </ul>
 
-        <ul class="lists listsButton">
-          <li class="list listSignin">
+        <ul class="lists authLinks">
+          <li class="list authLinksItem">
             <a class="signin" href="https://app.microcms.io/signin">ログイン</a>
           </li>
           <li class="list noMargin">
@@ -339,7 +339,7 @@ export default {
       display: flex;
     }
 
-    &.listsButton {
+    &.authLinks {
       margin-left: 10px;
     }
   }
@@ -354,7 +354,7 @@ export default {
       margin: 0;
     }
 
-    &.listSignin {
+    &.authLinksItem {
       margin-right: 16px;
     }
 
@@ -522,7 +522,7 @@ export default {
       flex-direction: column-reverse;
     }
 
-    &.listsButton {
+    &.authLinks {
       display: flex;
       flex-direction: row-reverse;
       padding-right: 10px;


### PR DESCRIPTION
サービスサイトに合わせてヘッダーとフッターを調整しました。
- グローバルメニューとフッターメニューに「パートナー」を追加しました。
- 「お問い合わせ」をプルダウンに変更しました。プルダウン内の各項目は下記のようにしています。（フッターメニューにも反映しています）
  - 「新規導入に関するご相談」→ コンタクトページ
  - 「パートナー紹介のご相談」→ パートナーを探すページの下部フォーム
- 「ログイン」をテキストからボタンに変更しました。
- スマホ版ではお問い合わせを先頭に配置しました。
- ヘッダーのブレイクポイントを800px→1240pxに変更しました。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
  - フッターのサイトマップを再編し、「お問い合わせ」および「パートナー」セクションを導入、リンクのラベルを分かりやすく変更しました。
  - ヘッダーにモバイル向けのお問い合わせ、ログイン、無料はじめるリンクと、パートナー関連のドロップダウンメニューを追加しました。
- **スタイル改善**
  - ヘッダーのレイアウト調整とブレークポイントの変更により、各要素の表示が最適化され、ユーザビリティが向上しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->