### PR TITLE
[add] リダイレクト設定を追加

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -2,36 +2,284 @@
   functions = "dist/api"
 
 [[redirects]]
-  from = "/usecase-interspace"
-  to = "https://microcms.io/interviews/usecase-interspace"
+  from = "/usecase-cainz/"
+  to = "https://microcms.io/interviews/usecase-cainz/"
   status = 302
   force = true
 
 [[redirects]]
-  from = "/usecase-interspace/"
-  to = "https://microcms.io/interviews/usecase-interspace"
+  from = "/usecase-web-creator-box/"
+  to = "https://microcms.io/interviews/usecase-web-creator-box/"
   status = 302
   force = true
 
 [[redirects]]
-  from = "/usecase-konicaminolta"
-  to = "https://microcms.io/interviews/usecase-konicaminolta"
+  from = "/usecase-fuller/"
+  to = "https://microcms.io/interviews/usecase-fuller/"
+  status = 302
+  force = true
+
+[[redirects]]
+  from = "/usecase-dip/"
+  to = "https://microcms.io/interviews/usecase-dip/"
+  status = 302
+  force = true
+
+[[redirects]]
+  from = "/usecase-gree-x/"
+  to = "https://microcms.io/interviews/usecase-gree-x/"
+  status = 302
+  force = true
+
+[[redirects]]
+  from = "/usecase-chunichi/"
+  to = "https://microcms.io/interviews/usecase-chunichi/"
+  status = 302
+  force = true
+
+[[redirects]]
+  from = "/usecase-ymj/"
+  to = "https://microcms.io/interviews/usecase-ymj/"
+  status = 302
+  force = true
+
+[[redirects]]
+  from = "/usecase-kinto/"
+  to = "https://microcms.io/interviews/usecase-kinto/"
+  status = 302
+  force = true
+
+[[redirects]]
+  from = "/usecase-nifty/"
+  to = "https://microcms.io/interviews/usecase-nifty/"
+  status = 302
+  force = true
+
+[[redirects]]
+  from = "/usecase-cerezo/"
+  to = "https://microcms.io/interviews/usecase-cerezo/"
+  status = 302
+  force = true
+
+[[redirects]]
+  from = "/usecase-scrap/"
+  to = "https://microcms.io/interviews/usecase-scrap/"
+  status = 302
+  force = true
+
+[[redirects]]
+  from = "/usecase-freee/"
+  to = "https://microcms.io/interviews/usecase-freee/"
+  status = 302
+  force = true
+
+[[redirects]]
+  from = "/usecase-tokyo-gas/"
+  to = "https://microcms.io/interviews/usecase-tokyo-gas/"
+  status = 302
+  force = true
+
+[[redirects]]
+  from = "/usecase-odx/"
+  to = "https://microcms.io/interviews/usecase-odx/"
+  status = 302
+  force = true
+
+[[redirects]]
+  from = "/usecase-alba/"
+  to = "https://microcms.io/interviews/usecase-alba/"
+  status = 302
+  force = true
+
+[[redirects]]
+  from = "/usecase-otamanabi-no-mori/"
+  to = "https://microcms.io/interviews/usecase-otamanabi-no-mori/"
+  status = 302
+  force = true
+
+[[redirects]]
+  from = "/usecase-elnet/"
+  to = "https://microcms.io/interviews/usecase-elnet/"
+  status = 302
+  force = true
+
+[[redirects]]
+  from = "/usecase-smarthr/"
+  to = "https://microcms.io/interviews/usecase-smarthr/"
+  status = 302
+  force = true
+
+[[redirects]]
+  from = "/usecase-leact/"
+  to = "https://microcms.io/interviews/usecase-leact/"
+  status = 302
+  force = true
+
+[[redirects]]
+  from = "/usecase-dmm/"
+  to = "https://microcms.io/interviews/usecase-dmm/"
+  status = 302
+  force = true
+
+[[redirects]]
+  from = "/usecase-housmart/"
+  to = "https://microcms.io/interviews/usecase-housmart/"
+  status = 302
+  force = true
+
+[[redirects]]
+  from = "/usecase-gvatech/"
+  to = "https://microcms.io/interviews/usecase-gvatech/"
+  status = 302
+  force = true
+
+[[redirects]]
+  from = "/usecase-toridoll/"
+  to = "https://microcms.io/interviews/usecase-toridoll/"
+  status = 302
+  force = true
+
+[[redirects]]
+  from = "/usecase-polimill/"
+  to = "https://microcms.io/interviews/usecase-polimill/"
+  status = 302
+  force = true
+
+[[redirects]]
+  from = "/usecase-reiwatravel/"
+  to = "https://microcms.io/interviews/usecase-reiwatravel/"
+  status = 302
+  force = true
+
+[[redirects]]
+  from = "/usecase-ndc/"
+  to = "https://microcms.io/interviews/usecase-ndc/"
+  status = 302
+  force = true
+
+[[redirects]]
+from = "/usecase-yamap-store/"
+to = "https://microcms.io/interviews/usecase-yamap-store/"
+status = 302
+force = true
+
+[[redirects]]
+  from = "/usecase-nrinetcom/"
+  to = "https://microcms.io/interviews/usecase-nrinetcom/"
+  status = 302
+  force = true
+
+[[redirects]]
+  from = "/usecase-discoveryjapan/"
+  to = "https://microcms.io/interviews/usecase-discoveryjapan/"
+  status = 302
+  force = true
+
+[[redirects]]
+  from = "/usecase-paconsul/"
+  to = "https://microcms.io/interviews/usecase-paconsul/"
+  status = 302
+  force = true
+
+[[redirects]]
+  from = "/usecase-chikaku/"
+  to = "https://microcms.io/interviews/usecase-chikaku/"
+  status = 302
+  force = true
+
+[[redirects]]
+  from = "/usecase-zozotech/"
+  to = "https://microcms.io/interviews/usecase-zozotech/"
+  status = 302
+  force = true
+
+[[redirects]]
+  from = "/usecase-sgis/"
+  to = "https://microcms.io/interviews/usecase-sgis/"
+  status = 302
+  force = true
+
+[[redirects]]
+  from = "/usecase-monex-am/"
+  to = "https://microcms.io/interviews/usecase-monex-am/"
+  status = 302
+  force = true
+
+[[redirects]]
+  from = "/usecase-dwango/"
+  to = "https://microcms.io/interviews/usecase-dwango/"
+  status = 302
+  force = true
+
+[[redirects]]
+  from = "/usecase-beatfit/"
+  to = "https://microcms.io/interviews/usecase-beatfit/"
+  status = 302
+  force = true
+
+[[redirects]]
+  from = "/usecase-odakyu/"
+  to = "https://microcms.io/interviews/usecase-odakyu/"
+  status = 302
+  force = true
+
+[[redirects]]
+  from = "/usecase-medley/"
+  to = "https://microcms.io/interviews/usecase-medley/"
+  status = 302
+  force = true
+
+[[redirects]]
+  from = "/usecase-port/"
+  to = "https://microcms.io/interviews/usecase-port/"
+  status = 302
+  force = true
+
+[[redirects]]
+  from = "/usecase-acall/"
+  to = "https://microcms.io/interviews/usecase-acall/"
+  status = 302
+  force = true
+
+[[redirects]]
+  from = "/usecase-knockonthedoor/"
+  to = "https://microcms.io/interviews/usecase-knockonthedoor/"
+  status = 302
+  force = true
+
+[[redirects]]
+  from = "/usecase-mediba/"
+  to = "https://microcms.io/interviews/usecase-mediba/"
+  status = 302
+  force = true
+
+[[redirects]]
+  from = "/crowdworks-with-microcms/"
+  to = "https://microcms.io/interviews/crowdworks-with-microcms/"
+  status = 302
+  force = true
+
+[[redirects]]
+  from = "/usecase-mediano/"
+  to = "https://microcms.io/interviews/usecase-mediano/"
   status = 302
   force = true
 
 [[redirects]]
   from = "/usecase-konicaminolta/"
-  to = "https://microcms.io/interviews/usecase-konicaminolta"
+  to = "https://microcms.io/interviews/usecase-konicaminolta/"
   status = 302
-
-[[redirects]]
-  from = "/usecase-rebuild"
-  to = "https://microcms.io/interviews/usecase-rebuild"
-  status = 302
+  force = true
 
 [[redirects]]
   from = "/usecase-rebuild/"
-  to = "https://microcms.io/interviews/usecase-rebuild"
+  to = "https://microcms.io/interviews/usecase-rebuild/"
+  status = 302
+  force = true
+
+[[redirects]]
+  from = "/usecase-interspace/"
+  to = "https://microcms.io/interviews/usecase-interspace/"
   status = 302
   force = true
 

--- a/netlify.toml
+++ b/netlify.toml
@@ -3,283 +3,283 @@
 
 [[redirects]]
   from = "/usecase-cainz/"
-  to = "https://microcms.io/interviews/usecase-cainz/"
+  to = "https://microcms.io/interviews/usecase-cainz"
   status = 302
   force = true
 
 [[redirects]]
   from = "/usecase-web-creator-box/"
-  to = "https://microcms.io/interviews/usecase-web-creator-box/"
+  to = "https://microcms.io/interviews/usecase-web-creator-box"
   status = 302
   force = true
 
 [[redirects]]
   from = "/usecase-fuller/"
-  to = "https://microcms.io/interviews/usecase-fuller/"
+  to = "https://microcms.io/interviews/usecase-fuller"
   status = 302
   force = true
 
 [[redirects]]
   from = "/usecase-dip/"
-  to = "https://microcms.io/interviews/usecase-dip/"
+  to = "https://microcms.io/interviews/usecase-dip"
   status = 302
   force = true
 
 [[redirects]]
   from = "/usecase-gree-x/"
-  to = "https://microcms.io/interviews/usecase-gree-x/"
+  to = "https://microcms.io/interviews/usecase-gree-x"
   status = 302
   force = true
 
 [[redirects]]
   from = "/usecase-chunichi/"
-  to = "https://microcms.io/interviews/usecase-chunichi/"
+  to = "https://microcms.io/interviews/usecase-chunichi"
   status = 302
   force = true
 
 [[redirects]]
   from = "/usecase-ymj/"
-  to = "https://microcms.io/interviews/usecase-ymj/"
+  to = "https://microcms.io/interviews/usecase-ymj"
   status = 302
   force = true
 
 [[redirects]]
   from = "/usecase-kinto/"
-  to = "https://microcms.io/interviews/usecase-kinto/"
+  to = "https://microcms.io/interviews/usecase-kinto"
   status = 302
   force = true
 
 [[redirects]]
   from = "/usecase-nifty/"
-  to = "https://microcms.io/interviews/usecase-nifty/"
+  to = "https://microcms.io/interviews/usecase-nifty"
   status = 302
   force = true
 
 [[redirects]]
   from = "/usecase-cerezo/"
-  to = "https://microcms.io/interviews/usecase-cerezo/"
+  to = "https://microcms.io/interviews/usecase-cerezo"
   status = 302
   force = true
 
 [[redirects]]
   from = "/usecase-scrap/"
-  to = "https://microcms.io/interviews/usecase-scrap/"
+  to = "https://microcms.io/interviews/usecase-scrap"
   status = 302
   force = true
 
 [[redirects]]
   from = "/usecase-freee/"
-  to = "https://microcms.io/interviews/usecase-freee/"
+  to = "https://microcms.io/interviews/usecase-freee"
   status = 302
   force = true
 
 [[redirects]]
   from = "/usecase-tokyo-gas/"
-  to = "https://microcms.io/interviews/usecase-tokyo-gas/"
+  to = "https://microcms.io/interviews/usecase-tokyo-gas"
   status = 302
   force = true
 
 [[redirects]]
   from = "/usecase-odx/"
-  to = "https://microcms.io/interviews/usecase-odx/"
+  to = "https://microcms.io/interviews/usecase-odx"
   status = 302
   force = true
 
 [[redirects]]
   from = "/usecase-alba/"
-  to = "https://microcms.io/interviews/usecase-alba/"
+  to = "https://microcms.io/interviews/usecase-alba"
   status = 302
   force = true
 
 [[redirects]]
   from = "/usecase-otamanabi-no-mori/"
-  to = "https://microcms.io/interviews/usecase-otamanabi-no-mori/"
+  to = "https://microcms.io/interviews/usecase-otamanabi-no-mori"
   status = 302
   force = true
 
 [[redirects]]
   from = "/usecase-elnet/"
-  to = "https://microcms.io/interviews/usecase-elnet/"
+  to = "https://microcms.io/interviews/usecase-elnet"
   status = 302
   force = true
 
 [[redirects]]
   from = "/usecase-smarthr/"
-  to = "https://microcms.io/interviews/usecase-smarthr/"
+  to = "https://microcms.io/interviews/usecase-smarthr"
   status = 302
   force = true
 
 [[redirects]]
   from = "/usecase-leact/"
-  to = "https://microcms.io/interviews/usecase-leact/"
+  to = "https://microcms.io/interviews/usecase-leact"
   status = 302
   force = true
 
 [[redirects]]
   from = "/usecase-dmm/"
-  to = "https://microcms.io/interviews/usecase-dmm/"
+  to = "https://microcms.io/interviews/usecase-dmm"
   status = 302
   force = true
 
 [[redirects]]
   from = "/usecase-housmart/"
-  to = "https://microcms.io/interviews/usecase-housmart/"
+  to = "https://microcms.io/interviews/usecase-housmart"
   status = 302
   force = true
 
 [[redirects]]
   from = "/usecase-gvatech/"
-  to = "https://microcms.io/interviews/usecase-gvatech/"
+  to = "https://microcms.io/interviews/usecase-gvatech"
   status = 302
   force = true
 
 [[redirects]]
   from = "/usecase-toridoll/"
-  to = "https://microcms.io/interviews/usecase-toridoll/"
+  to = "https://microcms.io/interviews/usecase-toridoll"
   status = 302
   force = true
 
 [[redirects]]
   from = "/usecase-polimill/"
-  to = "https://microcms.io/interviews/usecase-polimill/"
+  to = "https://microcms.io/interviews/usecase-polimill"
   status = 302
   force = true
 
 [[redirects]]
   from = "/usecase-reiwatravel/"
-  to = "https://microcms.io/interviews/usecase-reiwatravel/"
+  to = "https://microcms.io/interviews/usecase-reiwatravel"
   status = 302
   force = true
 
 [[redirects]]
   from = "/usecase-ndc/"
-  to = "https://microcms.io/interviews/usecase-ndc/"
+  to = "https://microcms.io/interviews/usecase-ndc"
   status = 302
   force = true
 
 [[redirects]]
 from = "/usecase-yamap-store/"
-to = "https://microcms.io/interviews/usecase-yamap-store/"
+to = "https://microcms.io/interviews/usecase-yamap-store"
 status = 302
 force = true
 
 [[redirects]]
   from = "/usecase-nrinetcom/"
-  to = "https://microcms.io/interviews/usecase-nrinetcom/"
+  to = "https://microcms.io/interviews/usecase-nrinetcom"
   status = 302
   force = true
 
 [[redirects]]
   from = "/usecase-discoveryjapan/"
-  to = "https://microcms.io/interviews/usecase-discoveryjapan/"
+  to = "https://microcms.io/interviews/usecase-discoveryjapan"
   status = 302
   force = true
 
 [[redirects]]
   from = "/usecase-paconsul/"
-  to = "https://microcms.io/interviews/usecase-paconsul/"
+  to = "https://microcms.io/interviews/usecase-paconsul"
   status = 302
   force = true
 
 [[redirects]]
   from = "/usecase-chikaku/"
-  to = "https://microcms.io/interviews/usecase-chikaku/"
+  to = "https://microcms.io/interviews/usecase-chikaku"
   status = 302
   force = true
 
 [[redirects]]
   from = "/usecase-zozotech/"
-  to = "https://microcms.io/interviews/usecase-zozotech/"
+  to = "https://microcms.io/interviews/usecase-zozotech"
   status = 302
   force = true
 
 [[redirects]]
   from = "/usecase-sgis/"
-  to = "https://microcms.io/interviews/usecase-sgis/"
+  to = "https://microcms.io/interviews/usecase-sgis"
   status = 302
   force = true
 
 [[redirects]]
   from = "/usecase-monex-am/"
-  to = "https://microcms.io/interviews/usecase-monex-am/"
+  to = "https://microcms.io/interviews/usecase-monex-am"
   status = 302
   force = true
 
 [[redirects]]
   from = "/usecase-dwango/"
-  to = "https://microcms.io/interviews/usecase-dwango/"
+  to = "https://microcms.io/interviews/usecase-dwango"
   status = 302
   force = true
 
 [[redirects]]
   from = "/usecase-beatfit/"
-  to = "https://microcms.io/interviews/usecase-beatfit/"
+  to = "https://microcms.io/interviews/usecase-beatfit"
   status = 302
   force = true
 
 [[redirects]]
   from = "/usecase-odakyu/"
-  to = "https://microcms.io/interviews/usecase-odakyu/"
+  to = "https://microcms.io/interviews/usecase-odakyu"
   status = 302
   force = true
 
 [[redirects]]
   from = "/usecase-medley/"
-  to = "https://microcms.io/interviews/usecase-medley/"
+  to = "https://microcms.io/interviews/usecase-medley"
   status = 302
   force = true
 
 [[redirects]]
   from = "/usecase-port/"
-  to = "https://microcms.io/interviews/usecase-port/"
+  to = "https://microcms.io/interviews/usecase-port"
   status = 302
   force = true
 
 [[redirects]]
   from = "/usecase-acall/"
-  to = "https://microcms.io/interviews/usecase-acall/"
+  to = "https://microcms.io/interviews/usecase-acall"
   status = 302
   force = true
 
 [[redirects]]
   from = "/usecase-knockonthedoor/"
-  to = "https://microcms.io/interviews/usecase-knockonthedoor/"
+  to = "https://microcms.io/interviews/usecase-knockonthedoor"
   status = 302
   force = true
 
 [[redirects]]
   from = "/usecase-mediba/"
-  to = "https://microcms.io/interviews/usecase-mediba/"
+  to = "https://microcms.io/interviews/usecase-mediba"
   status = 302
   force = true
 
 [[redirects]]
   from = "/crowdworks-with-microcms/"
-  to = "https://microcms.io/interviews/crowdworks-with-microcms/"
+  to = "https://microcms.io/interviews/crowdworks-with-microcms"
   status = 302
   force = true
 
 [[redirects]]
   from = "/usecase-mediano/"
-  to = "https://microcms.io/interviews/usecase-mediano/"
+  to = "https://microcms.io/interviews/usecase-mediano"
   status = 302
   force = true
 
 [[redirects]]
   from = "/usecase-konicaminolta/"
-  to = "https://microcms.io/interviews/usecase-konicaminolta/"
+  to = "https://microcms.io/interviews/usecase-konicaminolta"
   status = 302
   force = true
 
 [[redirects]]
   from = "/usecase-rebuild/"
-  to = "https://microcms.io/interviews/usecase-rebuild/"
+  to = "https://microcms.io/interviews/usecase-rebuild"
   status = 302
   force = true
 
 [[redirects]]
   from = "/usecase-interspace/"
-  to = "https://microcms.io/interviews/usecase-interspace/"
+  to = "https://microcms.io/interviews/usecase-interspace"
   status = 302
   force = true
 

--- a/netlify.toml
+++ b/netlify.toml
@@ -3,284 +3,284 @@
 
 [[redirects]]
   from = "/usecase-cainz/"
-  to = "https://microcms.io/interviews/usecase-cainz"
-  status = 302
+  to = "https://microcms.io/interviews/cainz"
+  status = 301
   force = true
 
 [[redirects]]
   from = "/usecase-web-creator-box/"
-  to = "https://microcms.io/interviews/usecase-web-creator-box"
-  status = 302
+  to = "https://microcms.io/interviews/web-creator-box"
+  status = 301
   force = true
 
 [[redirects]]
   from = "/usecase-fuller/"
-  to = "https://microcms.io/interviews/usecase-fuller"
-  status = 302
+  to = "https://microcms.io/interviews/fuller"
+  status = 301
   force = true
 
 [[redirects]]
   from = "/usecase-dip/"
-  to = "https://microcms.io/interviews/usecase-dip"
-  status = 302
+  to = "https://microcms.io/interviews/dip"
+  status = 301
   force = true
 
 [[redirects]]
   from = "/usecase-gree-x/"
-  to = "https://microcms.io/interviews/usecase-gree-x"
-  status = 302
+  to = "https://microcms.io/interviews/gree-x"
+  status = 301
   force = true
 
 [[redirects]]
   from = "/usecase-chunichi/"
-  to = "https://microcms.io/interviews/usecase-chunichi"
-  status = 302
+  to = "https://microcms.io/interviews/chunichi"
+  status = 301
   force = true
 
 [[redirects]]
   from = "/usecase-ymj/"
-  to = "https://microcms.io/interviews/usecase-ymj"
-  status = 302
+  to = "https://microcms.io/interviews/ymj"
+  status = 301
   force = true
 
 [[redirects]]
   from = "/usecase-kinto/"
-  to = "https://microcms.io/interviews/usecase-kinto"
-  status = 302
+  to = "https://microcms.io/interviews/kinto"
+  status = 301
   force = true
 
 [[redirects]]
   from = "/usecase-nifty/"
-  to = "https://microcms.io/interviews/usecase-nifty"
-  status = 302
+  to = "https://microcms.io/interviews/nifty"
+  status = 301
   force = true
 
 [[redirects]]
   from = "/usecase-cerezo/"
-  to = "https://microcms.io/interviews/usecase-cerezo"
-  status = 302
+  to = "https://microcms.io/interviews/cerezo"
+  status = 301
   force = true
 
 [[redirects]]
   from = "/usecase-scrap/"
-  to = "https://microcms.io/interviews/usecase-scrap"
-  status = 302
+  to = "https://microcms.io/interviews/scrap"
+  status = 301
   force = true
 
 [[redirects]]
   from = "/usecase-freee/"
-  to = "https://microcms.io/interviews/usecase-freee"
-  status = 302
+  to = "https://microcms.io/interviews/freee"
+  status = 301
   force = true
 
 [[redirects]]
   from = "/usecase-tokyo-gas/"
-  to = "https://microcms.io/interviews/usecase-tokyo-gas"
-  status = 302
+  to = "https://microcms.io/interviews/tokyo-gas"
+  status = 301
   force = true
 
 [[redirects]]
   from = "/usecase-odx/"
-  to = "https://microcms.io/interviews/usecase-odx"
-  status = 302
+  to = "https://microcms.io/interviews/odx"
+  status = 301
   force = true
 
 [[redirects]]
   from = "/usecase-alba/"
-  to = "https://microcms.io/interviews/usecase-alba"
-  status = 302
+  to = "https://microcms.io/interviews/alba"
+  status = 301
   force = true
 
 [[redirects]]
   from = "/usecase-otamanabi-no-mori/"
-  to = "https://microcms.io/interviews/usecase-otamanabi-no-mori"
-  status = 302
+  to = "https://microcms.io/interviews/otamanabi-no-mori"
+  status = 301
   force = true
 
 [[redirects]]
   from = "/usecase-elnet/"
-  to = "https://microcms.io/interviews/usecase-elnet"
-  status = 302
+  to = "https://microcms.io/interviews/elnet"
+  status = 301
   force = true
 
 [[redirects]]
   from = "/usecase-smarthr/"
-  to = "https://microcms.io/interviews/usecase-smarthr"
-  status = 302
+  to = "https://microcms.io/interviews/smarthr"
+  status = 301
   force = true
 
 [[redirects]]
   from = "/usecase-leact/"
-  to = "https://microcms.io/interviews/usecase-leact"
-  status = 302
+  to = "https://microcms.io/interviews/leact"
+  status = 301
   force = true
 
 [[redirects]]
   from = "/usecase-dmm/"
-  to = "https://microcms.io/interviews/usecase-dmm"
-  status = 302
+  to = "https://microcms.io/interviews/dmm"
+  status = 301
   force = true
 
 [[redirects]]
   from = "/usecase-housmart/"
-  to = "https://microcms.io/interviews/usecase-housmart"
-  status = 302
+  to = "https://microcms.io/interviews/housmart"
+  status = 301
   force = true
 
 [[redirects]]
   from = "/usecase-gvatech/"
-  to = "https://microcms.io/interviews/usecase-gvatech"
-  status = 302
+  to = "https://microcms.io/interviews/gvatech"
+  status = 301
   force = true
 
 [[redirects]]
   from = "/usecase-toridoll/"
-  to = "https://microcms.io/interviews/usecase-toridoll"
-  status = 302
+  to = "https://microcms.io/interviews/toridoll"
+  status = 301
   force = true
 
 [[redirects]]
   from = "/usecase-polimill/"
-  to = "https://microcms.io/interviews/usecase-polimill"
-  status = 302
+  to = "https://microcms.io/interviews/polimill"
+  status = 301
   force = true
 
 [[redirects]]
   from = "/usecase-reiwatravel/"
-  to = "https://microcms.io/interviews/usecase-reiwatravel"
-  status = 302
+  to = "https://microcms.io/interviews/reiwatravel"
+  status = 301
   force = true
 
 [[redirects]]
   from = "/usecase-ndc/"
-  to = "https://microcms.io/interviews/usecase-ndc"
-  status = 302
+  to = "https://microcms.io/interviews/ndc"
+  status = 301
   force = true
 
 [[redirects]]
 from = "/usecase-yamap-store/"
-to = "https://microcms.io/interviews/usecase-yamap-store"
-status = 302
+to = "https://microcms.io/interviews/yamap-store"
+status = 301
 force = true
 
 [[redirects]]
   from = "/usecase-nrinetcom/"
-  to = "https://microcms.io/interviews/usecase-nrinetcom"
-  status = 302
+  to = "https://microcms.io/interviews/nrinetcom"
+  status = 301
   force = true
 
 [[redirects]]
   from = "/usecase-discoveryjapan/"
-  to = "https://microcms.io/interviews/usecase-discoveryjapan"
-  status = 302
+  to = "https://microcms.io/interviews/discoveryjapan"
+  status = 301
   force = true
 
 [[redirects]]
   from = "/usecase-paconsul/"
-  to = "https://microcms.io/interviews/usecase-paconsul"
-  status = 302
+  to = "https://microcms.io/interviews/paconsul"
+  status = 301
   force = true
 
 [[redirects]]
   from = "/usecase-chikaku/"
-  to = "https://microcms.io/interviews/usecase-chikaku"
-  status = 302
+  to = "https://microcms.io/interviews/chikaku"
+  status = 301
   force = true
 
 [[redirects]]
   from = "/usecase-zozotech/"
-  to = "https://microcms.io/interviews/usecase-zozotech"
-  status = 302
+  to = "https://microcms.io/interviews/zozotech"
+  status = 301
   force = true
 
 [[redirects]]
   from = "/usecase-sgis/"
-  to = "https://microcms.io/interviews/usecase-sgis"
-  status = 302
+  to = "https://microcms.io/interviews/sgis"
+  status = 301
   force = true
 
 [[redirects]]
   from = "/usecase-monex-am/"
-  to = "https://microcms.io/interviews/usecase-monex-am"
-  status = 302
+  to = "https://microcms.io/interviews/monex-am"
+  status = 301
   force = true
 
 [[redirects]]
   from = "/usecase-dwango/"
-  to = "https://microcms.io/interviews/usecase-dwango"
-  status = 302
+  to = "https://microcms.io/interviews/dwango"
+  status = 301
   force = true
 
 [[redirects]]
   from = "/usecase-beatfit/"
-  to = "https://microcms.io/interviews/usecase-beatfit"
-  status = 302
+  to = "https://microcms.io/interviews/beatfit"
+  status = 301
   force = true
 
 [[redirects]]
   from = "/usecase-odakyu/"
-  to = "https://microcms.io/interviews/usecase-odakyu"
-  status = 302
+  to = "https://microcms.io/interviews/odakyu"
+  status = 301
   force = true
 
 [[redirects]]
   from = "/usecase-medley/"
-  to = "https://microcms.io/interviews/usecase-medley"
-  status = 302
+  to = "https://microcms.io/interviews/medley"
+  status = 301
   force = true
 
 [[redirects]]
   from = "/usecase-port/"
-  to = "https://microcms.io/interviews/usecase-port"
-  status = 302
+  to = "https://microcms.io/interviews/port"
+  status = 301
   force = true
 
 [[redirects]]
   from = "/usecase-acall/"
-  to = "https://microcms.io/interviews/usecase-acall"
-  status = 302
+  to = "https://microcms.io/interviews/acall"
+  status = 301
   force = true
 
 [[redirects]]
   from = "/usecase-knockonthedoor/"
-  to = "https://microcms.io/interviews/usecase-knockonthedoor"
-  status = 302
+  to = "https://microcms.io/interviews/knockonthedoor"
+  status = 301
   force = true
 
 [[redirects]]
   from = "/usecase-mediba/"
-  to = "https://microcms.io/interviews/usecase-mediba"
-  status = 302
+  to = "https://microcms.io/interviews/mediba"
+  status = 301
   force = true
 
 [[redirects]]
   from = "/crowdworks-with-microcms/"
   to = "https://microcms.io/interviews/crowdworks-with-microcms"
-  status = 302
+  status = 301
   force = true
 
 [[redirects]]
   from = "/usecase-mediano/"
-  to = "https://microcms.io/interviews/usecase-mediano"
-  status = 302
+  to = "https://microcms.io/interviews/mediano"
+  status = 301
   force = true
 
 [[redirects]]
   from = "/usecase-konicaminolta/"
-  to = "https://microcms.io/interviews/usecase-konicaminolta"
-  status = 302
+  to = "https://microcms.io/interviews/konicaminolta"
+  status = 301
   force = true
 
 [[redirects]]
   from = "/usecase-rebuild/"
-  to = "https://microcms.io/interviews/usecase-rebuild"
-  status = 302
+  to = "https://microcms.io/interviews/rebuild"
+  status = 301
   force = true
 
 [[redirects]]
   from = "/usecase-interspace/"
-  to = "https://microcms.io/interviews/usecase-interspace"
-  status = 302
+  to = "https://microcms.io/interviews/interspace"
+  status = 301
   force = true
 
 [[redirects]]

--- a/netlify.toml
+++ b/netlify.toml
@@ -5,16 +5,19 @@
   from = "/usecase-interspace"
   to = "https://microcms.io/interviews/usecase-interspace"
   status = 302
+  force = true
 
 [[redirects]]
   from = "/usecase-interspace/"
   to = "https://microcms.io/interviews/usecase-interspace"
   status = 302
+  force = true
 
 [[redirects]]
   from = "/usecase-konicaminolta"
   to = "https://microcms.io/interviews/usecase-konicaminolta"
   status = 302
+  force = true
 
 [[redirects]]
   from = "/usecase-konicaminolta/"
@@ -30,6 +33,7 @@
   from = "/usecase-rebuild/"
   to = "https://microcms.io/interviews/usecase-rebuild"
   status = 302
+  force = true
 
 [[redirects]]
   from = "/*"

--- a/netlify.toml
+++ b/netlify.toml
@@ -2,6 +2,26 @@
   functions = "dist/api"
 
 [[redirects]]
+  from = "/usecase-interspace"
+  to = "https://microcms.io/interviews/usecase-interspace"
+  status = 302
+
+[[redirects]]
+  from = "/usecase-interspace/"
+  to = "https://microcms.io/interviews/usecase-interspace"
+  status = 302
+
+[[redirects]]
+  from = "/usecase-konicaminolta"
+  to = "https://microcms.io/interviews/usecase-konicaminolta"
+  status = 302
+
+[[redirects]]
+  from = "/usecase-konicaminolta/"
+  to = "https://microcms.io/interviews/usecase-konicaminolta"
+  status = 302
+
+[[redirects]]
   from = "/usecase-rebuild"
   to = "https://microcms.io/interviews/usecase-rebuild"
   status = 302

--- a/netlify.toml
+++ b/netlify.toml
@@ -2,6 +2,16 @@
   functions = "dist/api"
 
 [[redirects]]
+  from = "/usecase-rebuild"
+  to = "https://microcms.io/interviews/usecase-rebuild"
+  status = 302
+
+[[redirects]]
+  from = "/usecase-rebuild/"
+  to = "https://microcms.io/interviews/usecase-rebuild"
+  status = 302
+
+[[redirects]]
   from = "/*"
   to = "/404.html"
   status = 404

--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -348,12 +348,9 @@ export default {
     },
     dir: 'dist',
     exclude: [
-      '/usecase-interspace',
-      '/usecase-interspace/',
-      '/usecase-konicaminolta',
-      '/usecase-konicaminolta/',
-      '/usecase-rebuild',
-      '/usecase-rebuild/',
+      /^\/usecase-interspace\/?$/,
+      /^\/usecase-konicaminolta\/?$/,
+      /^\/usecase-rebuild\/?$/,
     ],
   },
   sitemap: {

--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -347,11 +347,6 @@ export default {
       ];
     },
     dir: 'dist',
-    exclude: [
-      /^\/usecase-interspace\/?$/,
-      /^\/usecase-konicaminolta\/?$/,
-      /^\/usecase-rebuild\/?$/,
-    ],
   },
   sitemap: {
     path: '/sitemap.xml',

--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -98,14 +98,14 @@ export default {
     GTM_ID ? ['@nuxtjs/gtm'] : undefined,
     FB_PIXEL_ID
       ? [
-          'nuxt-facebook-pixel-module',
-          {
-            track: 'PageView',
-            pixelId: FB_PIXEL_ID,
-            autoPageView: true,
-            disabled: false,
-          },
-        ]
+        'nuxt-facebook-pixel-module',
+        {
+          track: 'PageView',
+          pixelId: FB_PIXEL_ID,
+          autoPageView: true,
+          disabled: false,
+        },
+      ]
       : undefined,
     ['@nuxtjs/sitemap'],
     '@nuxtjs/feed',
@@ -347,6 +347,11 @@ export default {
       ];
     },
     dir: 'dist',
+    exclude: [
+      /^\/usecase-interspace\/?$/,
+      /^\/usecase-konicaminolta\/?$/,
+      /^\/usecase-rebuild\/?$/,
+    ],
   },
   sitemap: {
     path: '/sitemap.xml',

--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -348,9 +348,12 @@ export default {
     },
     dir: 'dist',
     exclude: [
-      /^\/usecase-interspace\/?$/,
-      /^\/usecase-konicaminolta\/?$/,
-      /^\/usecase-rebuild\/?$/,
+      '/usecase-interspace',
+      '/usecase-interspace/',
+      '/usecase-konicaminolta',
+      '/usecase-konicaminolta/',
+      '/usecase-rebuild',
+      '/usecase-rebuild/',
     ],
   },
   sitemap: {

--- a/static/_redirects
+++ b/static/_redirects
@@ -1,3 +1,4 @@
 /usecase-interspace/  https://microcms.io/interviews/usecase-interspace  302
-/usecase-rebuild/  https://microcms.io/interviews/usecase-rebuild  302
+/usecase-interspace  https://microcms.io/interviews/usecase-interspace  302
 /usecase-konicaminolta/  https://microcms.io/interviews/usecase-konicaminolta  302
+/usecase-konicaminolta  https://microcms.io/interviews/usecase-konicaminolta  302

--- a/static/_redirects
+++ b/static/_redirects
@@ -1,0 +1,3 @@
+/usecase-interspace/  https://microcms.io/interviews/usecase-interspace  302
+/usecase-rebuild/  https://microcms.io/interviews/usecase-rebuild  302
+/usecase-konicaminolta/  https://microcms.io/interviews/usecase-konicaminolta  302

--- a/static/_redirects
+++ b/static/_redirects
@@ -1,4 +1,0 @@
-/usecase-interspace/  https://microcms.io/interviews/usecase-interspace  302
-/usecase-interspace  https://microcms.io/interviews/usecase-interspace  302
-/usecase-konicaminolta/  https://microcms.io/interviews/usecase-konicaminolta  302
-/usecase-konicaminolta  https://microcms.io/interviews/usecase-konicaminolta  302


### PR DESCRIPTION
検証のため3記事分のリダイレクトルールのみ設定

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **新機能**
  - 指定されたURLにアクセスすると、各インタビューのページへ一時的に転送されるリダイレクトルールを66件追加しました。これにより、ユーザーは関連コンテンツにスムーズにアクセスできるようになります。
- **変更点**
  - Facebook Pixelモジュールの設定を再フォーマットしましたが、機能やロジックには影響ありません。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->