### PR TITLE
動画リンクを埋め込めるように変更

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,6 +1,6 @@
 {
   "editor.codeActionsOnSave": {
-    "source.fixAll.eslint": true
+    "source.fixAll.eslint": "explicit"
   },
   "editor.formatOnSave": true
 }

--- a/components/Post.vue
+++ b/components/Post.vue
@@ -213,6 +213,12 @@ export default {
       box-shadow: 0 0 10px rgba(0, 0, 0, 0.1);
     }
 
+    & >>> video {
+      max-width: 100%;
+      margin: 40px 0;
+      box-shadow: 0 0 10px rgba(0, 0, 0, 0.1);
+    }
+
     & >>> a {
       color: #331cbf;
       text-decoration: underline;

--- a/components/Post.vue
+++ b/components/Post.vue
@@ -93,6 +93,12 @@ export default {
       box-shadow: 0 0 10px rgba(0, 0, 0, 0.1);
     }
 
+    & >>> video {
+      max-width: 100%;
+      margin: 40px 0;
+      box-shadow: 0 0 10px rgba(0, 0, 0, 0.1);
+    }
+
     & >>> a {
       color: var(--color-purple);
       text-decoration: underline;

--- a/pages/_slug/index.vue
+++ b/pages/_slug/index.vue
@@ -154,6 +154,16 @@ export default {
       $(elm).attr('data-src', elm.attribs.src);
       $(elm).removeAttr('src');
     });
+    $('a').each((_, elm) => {
+      // hrefが動画リンクのものはvideoタグを作成し、srcにhrefの値を設定
+      if ($(elm).attr('href').endsWith('.mp4')) {
+        const video = $('<video></video>');
+        video.attr('src', $(elm).attr('href'));
+        video.attr('controls', 'controls');
+        video.attr('preload', 'metadata');
+        $(elm).replaceWith(video);
+      }
+    });
 
     data.related_blogs.forEach((blog) => {
       blog.defaultOgimage = getDefaultOgimage(blog);

--- a/pages/draft/index.vue
+++ b/pages/draft/index.vue
@@ -188,6 +188,16 @@ export default {
       $(elm).html(res.value);
       $(elm).addClass('hljs');
     });
+    $('a').each((_, elm) => {
+      // hrefが動画リンクのものはvideoタグを作成し、srcにhrefの値を設定
+      if ($(elm).attr('href').endsWith('.mp4')) {
+        const video = $('<video></video>');
+        video.attr('src', $(elm).attr('href'));
+        video.attr('controls', 'controls');
+        video.attr('preload', 'metadata');
+        $(elm).replaceWith(video);
+      }
+    });
     this.data.body = $.html();
     this.data.defaultOgimage = getDefaultOgimage(this.data);
     this.data.related_blogs.forEach((blog) => {


### PR DESCRIPTION
Slackでの相談の通りです！

aタグにmp4リンクを指定した場合にvideoタグに変換するように変更しました。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- 新機能
  - 投稿ページと下書きプレビューで、.mp4 へのリンクを自動的に埋め込み動画プレーヤー（controls, preload="metadata"）に置換。SSR/CSR両方の処理パスで適用されるよう重複処理を追加。
- スタイル
  - 投稿内の動画にデスクトップ/モバイルとも画像と同等の最大幅・余白・ボックスシャドウを適用。
- 雑務
  - エディタの保存時に実行する ESLint 自動修正設定の値を明確化（boolean→文字列）。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->