### PR TITLE
feature: バナー画像のborder-radiusを削除

### DIFF
--- a/components/Banner.vue
+++ b/components/Banner.vue
@@ -43,7 +43,6 @@ export default {
 .image {
   width: 300px;
   height: auto;
-  border-radius: 5px;
 }
 
 .link {


### PR DESCRIPTION
バナー画像のデザインにあわせて、`border-radius`を削除しました。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **スタイル変更**
  * バナーコンポーネント内の画像の角丸デザインを削除し、直角の表示に変更しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->